### PR TITLE
Remove information about time interval for NCAR little_r format

### DIFF
--- a/module_obsproc.sh
+++ b/module_obsproc.sh
@@ -14,7 +14,7 @@ ln -fs $WRFDA_DIR/var/obsproc/obsproc.exe .
 ln -fs $WRFDA_DIR/var/obsproc/obserr.txt .
 echo > obs.raw
 
-##### include NCAR_LITTLE_R (3-hourly) #####
+##### include NCAR_LITTLE_R #####
 if $INCLUDE_LITTLE_R; then
   rm -f datelist
   time_lag=0


### PR DESCRIPTION
Since NCAR little_r is 3-hourly but the katrina case uses 6-hourly MADIS data (in little_r format), this comment could be confusing.