### PR TITLE
Use perturbed boundary conditions in ensemble simulations

### DIFF
--- a/module_wrf_ens.sh
+++ b/module_wrf_ens.sh
@@ -112,8 +112,8 @@ for r in 1 3; do
       dm=d`expr $n + 100 |cut -c2-`
       ln -fs ../../../../fc/$DATE/wrfinput_${dm}_$id wrfinput_$dm
     done
-#    ln -fs ../../../../fc/wrfbdy_d01_$id wrfbdy_d01
-    ln -fs ../../../../rc/$DATE_START/wrfbdy_d01 wrfbdy_d01
+    ln -fs ../../../../fc/wrfbdy_d01_$id wrfbdy_d01
+#    ln -fs ../../../../rc/$DATE_START/wrfbdy_d01 wrfbdy_d01
 
     if [ $DATE -gt $DATE_START ]; then
       $SCRIPT_DIR/multi_physics_set.sh $id >& multi_physics_set.log


### PR DESCRIPTION
Not sure if this is desired or not, but it looks like wrf_ens simulations use wrfbdy_d01 from rc, while the outputs from wrf_update_bc are stored in fc.

Haven't tested running the case with this change yet.